### PR TITLE
Slightly improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,13 +46,13 @@ jobs:
         patterns: |
           +**/*.java
           -**/*Test*.java
-        input: sarif-results/java.sarif
-        output: sarif-results/java.sarif
+        input: sarif-results/${{ matrix.language }}.sarif
+        output: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload SARIF
       uses: github/codeql-action/upload-sarif@v1
       with:
-        sarif_file: sarif-results/java.sarif
+        sarif_file: sarif-results/${{ matrix.language }}.sarif
 
     - name: Upload loc as a Build Artifact
       uses: actions/upload-artifact@v2.2.0


### PR DESCRIPTION
Using `${{ matrix.language }}` instead of `java` when referencing the `.sarif` files. 

This way this won't break if you have multiple languages (ie: javascript and python) in the same repository being scanned in the same workflow. 