### PR TITLE
Fix for incorrect `github.action_path` in containers

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -16,5 +16,5 @@ runs:
     - name: filter
       run: |
         unset LD_PRELOAD
-        python3 "${{ github.action_path }}/filter_sarif.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "${{ inputs.patterns }}"
+        python3 "$GITHUB_ACTION_PATH/filter_sarif.py" --input "${{ inputs.input }}" --output "${{ inputs.output }}" --split-lines -- "${{ inputs.patterns }}"
       shell: bash


### PR DESCRIPTION
When run in a container, the `github.action_path` doen't point to the right place. The `GITHUB_ACTION_PATH` env var does.

This issue has been raised in the `actions/runner` repo. That repo claims it's fixed, but it's not deployed on all hosted runners, it would seem!

https://github.com/actions/runner/issues/716

I'm not aware of any downside to using the env var instead of the context var here.